### PR TITLE
cEP-1: Remove "forking in case of fraud" statement

### DIFF
--- a/cEP-1.md
+++ b/cEP-1.md
@@ -37,9 +37,6 @@ Limited Dictator (short: BLD).
 The BLD is a coala member with additional veto rights as described below. As
 per this cEP, Lasse Schuirmann is the BLD for coala.
 
-The community may at all times abandon the project and create a fork if the BLD
-acts stupidishly or is uncovered a fraud.
-
 Decision Types
 --------------
 


### PR DESCRIPTION
The deleted sentence in question might be interpreted as
"the community may not fork the project unless the bld acts stupidly
or is uncovered a fraud."

It is also obvious, slightly off-topic (as forking shouldn't clash
with the existence of a BLD) and written wrongly.

Fixes https://github.com/coala-analyzer/cEPs/issues/3
