### PR TITLE
cEP-0000: Allow letters after cEP numbers to define sub-cEPs

### DIFF
--- a/cEP-0000.md
+++ b/cEP-0000.md
@@ -4,7 +4,7 @@ coala Enhancement Proposals
 |Metadata|                                   |
 |--------|-----------------------------------|
 |cEP     |0000                               |
-|Version |2.0                                |
+|Version |2.1                                |
 |Title   |coala Enhancement Proposals        |
 |Authors |Lasse Schuirmann <lasse@gitmate.io>|
 |Status  |Active                             |
@@ -27,7 +27,7 @@ Spelling
 --------
 
 As we all know, coala is written with a lower case c. The proper spelling of a
-cEP is `cEP-####`.
+cEP is `cEP-[0-9]{4}([a-z])?`, so `cEP-####` or `cEP-####x`.
 
 Invalid ways to express cEP specifications include `CEP-####`, `cEP####`,
 `cep-####`, and `cEP-#`.
@@ -59,6 +59,9 @@ Metadata
 The metadata table must hold the following items:
 
 - A **cEP** number. This number is final.
+- An optional letter after the **cEP** number to define sub-cEPs. This letter
+  is also final. A sub-cEP must be related to an existing parent cEP and is
+  only allowed if its content would inappropriately bloat the parent cEP.
 - A **Version** number. Initially proposed cEPs start with 0.1 and raise until
   they get accepted, which bumps the version to 1.0. They may be iterated upon
   using [semantic versioning](http://semver.org/).


### PR DESCRIPTION
Due to a recent need to define sub-cEPs for existing cEPs, this should be merged :)