### PR TITLE
cEP-0000.md: Allow cEP-# instead of cEP-####

### DIFF
--- a/cEP-0000.md
+++ b/cEP-0000.md
@@ -4,7 +4,7 @@ coala Enhancement Proposals
 |Metadata|                                   |
 |--------|-----------------------------------|
 |cEP     |0000                               |
-|Version |2.1                                |
+|Version |2.2                                |
 |Title   |coala Enhancement Proposals        |
 |Authors |Lasse Schuirmann <lasse@gitmate.io>|
 |Status  |Active                             |

--- a/cEP-0000.md
+++ b/cEP-0000.md
@@ -28,9 +28,11 @@ Spelling
 
 As we all know, coala is written with a lower case c. The proper spelling of a
 cEP is `cEP-[0-9]{4}([a-z])?`, so `cEP-####` or `cEP-####x`.
+A cEP may also be spelled as `cEP-#` , `cEP-##` or `cEP-###` in case the
+author wants to.
 
 Invalid ways to express cEP specifications include `CEP-####`, `cEP####`,
-`cep-####`, and `cEP-#`.
+`cep-####`, `Cep-####`, `CeP-####` and `CEp-####`.
 
 Purpose
 -------


### PR DESCRIPTION
This allows authors to write cEPs without the need
the need to add un-necessary leading zeroes.

Fixes https://github.com/coala/cEPs/issues/16