### PR TITLE
cEP-0001: Remove BLD

### DIFF
--- a/cEP-0001.md
+++ b/cEP-0001.md
@@ -4,7 +4,7 @@ Decision Making in coala
 |Metadata|                                                                    |
 |--------|--------------------------------------------------------------------|
 |cEP     |0001                                                                |
-|Version |1.1                                                                 |
+|Version |2.0                                                                 |
 |Title   |Decision Making in coala                                            |
 |Authors |Lasse Schuirmann <lasse@gitmate.io>, Mischa Krüger <makman@alice.de>|
 |Status  |Active                                                              |
@@ -29,14 +29,6 @@ The following roles may be involved in decisions:
 Contributors may be promoted to members with a level B decision. Members have
 normal voting rights as described below.
 
-### Benevolent Limited Dictator (BLD)
-
-Members of the coala community have suggested the establishment of a Benevolent
-Limited Dictator (short: BLD).
-
-The BLD is a coala member with additional veto rights as described below. As
-per this cEP, Lasse Schuirmann is the BLD for coala.
-
 Decision Types
 --------------
 
@@ -54,8 +46,7 @@ community. The decision in favour or against the proposal may be determined if
 two more members are for it than against it (or against it than for it
 respectively).
 
-If no agreement is possible, a C level decision can be made. The BLD may raise
-the decision to a C level decision at will.
+If no agreement is possible, a C level decision can be made.
 
 ### C Level Decision
 
@@ -64,7 +55,5 @@ members channel and via the coala-members mailing list. The vote must be up for
 at least one week and is available to all members.
 
 For a decision to happen, a simple majority of all participating members must
-exist. If the same number of members is in favor as against the decision, the
-BLD may decide. The BLD also may block a decision with reasons provided within
-the week of voting. In this case no decision is made and discussions may
-continue.
+exist. If the same number of members is in favor as against the decision, no
+decision is made and discussions may continue.


### PR DESCRIPTION
The concept of the BLD was based on suggestions from several community members requesting centralized leadership at that time.

I believe coala has grown up and that the concept of the BLD is no longer needed.

There is a diverse set of very capable people, maintainers are starting to meet regularly to give coala a clear direction. Our democratic processes are maturing and our community is able to make better decisions than a single person could do.