### PR TITLE
cEP-0010.md: Fix a typo

### DIFF
--- a/cEP-0010.md
+++ b/cEP-0010.md
@@ -192,7 +192,7 @@ represents the naming convention used for functions' or methods'.
 naming convention being used for classes.
 * `Root.Smell.Naming.max_identifier_length`: This taste represents the max
 length for an identifier.
-* `Root.Smell.Naming.max_identifier_length`: This taste represents the min
+* `Root.Smell.Naming.min_identifier_length`: This taste represents the min
 length for an identifier.
 * `Root.Redundancy`: This aspect describes redundancy in your source code.
 * `Root.Redundancy.Clone`: This aspect detects code


### PR DESCRIPTION
Removed Root.Formatting.Quotation.prefered_quotation on line 141
Removed Root.Formatting.FileLength.max_file_length on line 155
Appended max_identifier_length with min_identifier_length on line 194

Closes https://github.com/coala/cEPs/issues/93