### PR TITLE
cEP-0006.md: Fix typo

### DIFF
--- a/cEP-0006.md
+++ b/cEP-0006.md
@@ -81,7 +81,7 @@ coala DOT io`.
   to err and blaming each other doesn’t get us anywhere. Instead, focus on
   helping to resolve issues and learning from mistakes.
 
-Original text courtesy of the [Speak Up! project] (http://web.archive.org/web/20141109123859/http://speakup.io/coc.html).
+Original text courtesy of the [Speak Up! project](http://web.archive.org/web/20141109123859/http://speakup.io/coc.html).
 
 # Questions?
 


### PR DESCRIPTION
The link on line 84 is now formatted correctly.

Fixes https://github.com/coala/cEPs/issues/92