### PR TITLE
Fixed typo 

### DIFF
--- a/cEP-0002.md
+++ b/cEP-0002.md
@@ -30,7 +30,7 @@ avoid.
 
 The new proposal aims to eliminate the use of the queuing control signals
 utilising asynchronous I/O and process pool to generate results from the
-bears. No longer will the local bears be dependent on global bears to finish.
+bears. No longer will the global bears be dependent on local bears to finish.
 The logging will also be handled by the main thread itself instead of
 utilising an extra thread.
 


### PR DESCRIPTION
cEP-0002.md: Correct sentence 

This corrects the phrasing mistake and interchanges
the words 'local' and 'global'.

Closes #98
