### PR TITLE
cEP-0001: Fix link to newcomer guide

### DIFF
--- a/cEP-0001.md
+++ b/cEP-0001.md
@@ -29,7 +29,7 @@ A newcomer is someone that was just introduced to the coala project and
 community and begins to contribute to it. This rank mainly represents the
 learning phase of the contribution process.
 
-Every org member that started following the [newcomer guide](coala.io/newcomer)
+Every org member that started following the [newcomer guide](//coala.io/newcomer)
 is declared a newcomer by invitation into the GitHub organisation. Newcomers can
 work on issues with an assignment.
 


### PR DESCRIPTION
Before:
>[newcomer guide](coala.io/newcomer)

After:
>[newcomer guide](//coala.io/newcomer)

Fixes https://github.com/coala/cEPs/issues/109