### PR TITLE
Typo fixed - 'doxing' changed to 'doxxing'

### DIFF
--- a/cEP-0006.md
+++ b/cEP-0006.md
@@ -65,7 +65,7 @@ coala DOT io`.
   * Discriminatory jokes and language.
   * Posting sexually explicit or violent material.
   * Posting (or threatening to post) other people's personally identifying
-    information ("doxing").
+    information ("doxxing").
   * Personal insults, especially those using racist or sexist terms.
   * Unwelcome sexual attention.
   * Advocating for, or encouraging, any of the above behavior.


### PR DESCRIPTION
**cEP-0006.md**: Fix _doxing_ typo

This fixes the typo and changes
it from **doxing** --> **doxxing**.

Fixes : https://github.com/coala/cEPs/issues/100