### PR TITLE
cEP-0006.md: Fix doxing typo

### DIFF
--- a/cEP-0006.md
+++ b/cEP-0006.md
@@ -85,5 +85,4 @@ Original text courtesy of the [Speak Up! project] (http://web.archive.org/web/20
 
 # Questions?
 
-If you have questions, feel free to contact us by emailing `community AT
-coala DOT io`.
+If you have questions, feel free to contact us by emailing `community AT coala DOT io`.

--- a/cEP-0006.md
+++ b/cEP-0006.md
@@ -65,7 +65,7 @@ coala DOT io`.
   * Discriminatory jokes and language.
   * Posting sexually explicit or violent material.
   * Posting (or threatening to post) other people's personally identifying
-    information ("doxing").
+    information ("doxxing").
   * Personal insults, especially those using racist or sexist terms.
   * Unwelcome sexual attention.
   * Advocating for, or encouraging, any of the above behavior.


### PR DESCRIPTION
This fixes the typo and changes it from **doxing** --> **doxxing**.  

Fixes : https://github.com/coala/cEPs/issues/100