### PR TITLE
cEPs/README.md: Fix readme file typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ in the `cEP-0000.md` document.
 |[cEP-0001](cEP-0001.md) | Decision Making in coala | This cEP describes the official roles members of the coala community can hold and how they can vote on different levels of decisions. |
 | [cEP-0002](cEP-0002.md) | Next Gen Bear Design | This cEP describes a new implementation of bears in coala which should make them simpler and make their design more intuitive and better. |
 | [cEP-0003](cEP-0003.md) | Teams in coala|This is a proposal on how to decentralize the management of coala by introducing teams. |
-| [cEP-0005](cEP-0005.md) | Coala Configuration|One main pain point for our users is that coala is hard to configure. |
-| [cEP-0006](cEP-0006.md) | Coala Community Code of Conduct | Like the technical community as a whole, the coala team and community is made up of a mixture of professionals and volunteers from all over the world,working on every aspect of the mission - including mentorship, teaching, and connecting people. |
+| [cEP-0005](cEP-0005.md) | coala Configuration|One main pain point for our users is that coala is hard to configure. |
+| [cEP-0006](cEP-0006.md) | coala Community Code of Conduct | Like the technical community as a whole, the coala team and community is made up of a mixture of professionals and volunteers from all over the world,working on every aspect of the mission - including mentorship, teaching, and connecting people. |
 | [cEP-0009](cEP-0009.md) | Change status | This cEP proposes a mechnaism to represent and extract information from project files and an interface to utilize the extracted information. |
 | [cEP-0010](cEP-0010.md) |Convert bears to use aspects | This document describes how `aspects` will be defined for and connected with bears and how their results will be annotated with them. |
-| [cEP-0012](cEP-0012.md) | Coala's Command Line Interface|This cEP describes the design of coala's Command Line Interface (the action selection screen). |
+| [cEP-0012](cEP-0012.md) | coala's Command Line Interface|This cEP describes the design of coala's Command Line Interface (the action selection screen). |
 | [cEP-0013](cEP-0013.md) | Cobot Enhancement and porting|This cEP describes about the new features that are to be added to cobot as a part of the [GSoC project](https://summerofcode.withgoogle.com/projects/#4913450777051136). |
 | [cEP-0014](cEP-0014.md) | Generate relevant coafile sections | This cEP proposes a framework for coala-quickstart to generate more relevant `.coafile` sections based on project files and user preferences. |


### PR DESCRIPTION
This fixes the typo in cEP titles and changes it from Coala --> coala.

Fixes https://github.com/coala/cEPs/issues/111