### PR TITLE
cEP-0018.md: Add information about fixes

### DIFF
--- a/cEP-0018.md
+++ b/cEP-0018.md
@@ -272,3 +272,266 @@ class TestBear(ASTBear):
             """
         ...
 ```
+
+## Providing Fixes with the library
+
+ANTLR has a `HiddenTokenStream` which recieves all the tokens irrelevant to the
+parser such as whitespaces. These are not passed on to the parser and as a
+result are not returned when simply fetching text from a node in parse tree.
+
+Consider the code:
+
+```python
+def do_nothing():
+    pass
+
+def run_coala(console_printer=None,
+              log_printer=None,
+              print_results=do_nothing,
+              print_section_beginning=do_nothing,
+              nothing_done=do_nothing,
+              autoapply=True,
+              force_show_patch=False,
+              arg_parser=None,
+              arg_list=None,
+              args=None,
+              debug=False):
+    """
+    This function signature has been taken from coala-core for fairly complex
+    example.
+    """
+    print('This function will do something')
+    if (console_printer and
+        log_printer and
+        not (args == None and debug == False)
+        ):
+       print('These conditions were made to trick !')
+       print(' !(a & b) == !a or !b')
+```
+
+The corresponding parse-tree:
+![example_tree_complex](https://user-images.githubusercontent.com/10978108/43427185-22237564-9476-11e8-8de0-c93692eaa958.jpg)
+
+After converting this source back using:
+
+```python
+#!/usr/bin/env python
+from antlr4 import *
+from Python3Lexer import Python3Lexer
+from Python3Parser import Python3Parser
+from Python3Visitor import Python3Visitor
+
+import sys
+
+class Visitor(Python3Visitor):
+    def visitFile_input(self, ctx):
+        print(ctx.getText())
+
+def main(args):
+    file = FileStream(args[1])
+    lexer = Python3Lexer(file)
+    stream = CommonTokenStream(lexer)
+    parser = Python3Parser(stream)
+
+    tre = parser.file_input()
+    if parser.getNumberOfSyntaxErrors()!=0:
+        print("File contains {} "
+              "syntax errors".format(parser.getNumberOfSyntaxErrors()))
+        return
+
+    visitor = Visitor()
+    visitor.stream = stream
+    visitor.visit(tre)
+
+if __name__ == '__main__':
+    main(sys.argv)
+```
+
+We get the following output:
+
+```python
+defdo_nothing():
+    pass
+
+defrun_coala(console_printer=None,log_printer=None,print_results=do_nothing,print_section_beginning=do_nothing,nothing_done=do_nothing,autoapply=True,force_show_patch=False,arg_parser=None,arg_list=None,args=None,debug=False):
+    """
+    This function signature has been taken from coala-core for fairly complex
+    example.
+    """
+print('This function will do something')
+if(console_printerandlog_printerandnot(args==Noneanddebug==False)):
+       print('These conditions were made to trick !')
+print(' !(a & b) == !a or !b')
+
+
+<EOF>
+```
+
+The most important points to note in the above are (Especially with respect
+to a `Python` grammar scenario):
+
+- All spaces within two tokens has been removed unless present inside a string
+- All newlines have been stripped unless the newline is specified by the
+  grammar to be present in the parse tree. With reference to the Python grammar
+  the newlines are present irregularly because they are preserved only in case
+  of the `compound_stmt` rule.
+- All information about the indentation in the code is lost, which makes it
+  impossible for the fixer to suggest a complex fix without guessing the
+  indentation.
+
+Despite of all the above, ANTLR provides us a line number and a column number
+for each `Terminal Node`.
+Thus, keeping all the above in mind, the bears written with this library can
+provide some fixes for linting errors, and such a fix is provided in
+implementation by the `PyPluralBear`. Once a complete roundtrip mechanism is
+possible, any kind of fix can be done and the library can also provide
+functions for doing so, but this is not in the scope of this project, due to
+the forementioned facts.
+
+Manual space insertion can be done using:
+
+```python
+#!/usr/bin/env python
+from antlr4 import *
+from Python3Lexer import Python3Lexer
+from Python3Parser import Python3Parser
+from Python3Visitor import Python3Visitor
+
+import sys
+
+class Visitor(Python3Visitor):
+    def visitTerminal(self, node):
+        line = node.getPayload().line
+        col = node.getPayload().column+1
+        self.nodeinfo.append((line,col,node.getText(), type(node.parentCtx)))
+
+def print_source(node_list):
+    current_line=1
+    current_column=1
+    for element in sorted(node_list):
+        while current_line<element[0]:
+            current_column=1
+            current_line+=1
+            print("")
+
+        while current_column<=element[1]-1:
+            current_column+=1
+            print(" ", end="")
+
+        if element[2]!='\n' and element[2]!='\t' and element[2].strip()!='':
+            print(element[2], end="")
+            current_column = current_column + len(element[2])
+        if element[2].count('\n') and element[2]!='\n':
+            current_column = 1
+            current_line += element[2].count('\n')
+            print("")
+
+def main(args):
+    file = FileStream(args[1])
+    lexer = Python3Lexer(file)
+    stream = CommonTokenStream(lexer)
+    parser = Python3Parser(stream)
+
+    tre = parser.file_input()
+    if parser.getNumberOfSyntaxErrors()!=0:
+        print("File contains {} "
+              "syntax errors".format(parser.getNumberOfSyntaxErrors()))
+        return
+
+    visitor = Visitor()
+    visitor.stream = stream
+    visitor.nodeinfo = []
+    visitor.visit(tre)
+    print_source(visitor.nodeinfo)
+
+if __name__ == '__main__':
+    main(sys.argv)
+```
+
+But the above also poses complications, especially when the source grammar uses
+stray nodes. For e.g the Python grammar uses nodes that the Python grammar for
+Java doesn't use. This forces antlr programs written using Python to deal with
+stray character nodes as of this cEP. Since the library can interface with
+arbitrary, but correct ANTLR grammar, it currently cannot detect these stray
+nodes automatically.
+
+An example of these stray nodes can be seen using the Python3 grammar with a
+source that is indented using spaces.
+
+Sample output for the above input code using the improvised pretty printer:
+
+```python
+def do_nothing():
+ hpass
+
+def run_coala(console_printer=None,
+     log_printer=None,
+     print_results=do_nothing,
+     print_section_beginning=do_nothing,
+     nothing_done=do_nothing,
+     autoapply=True,
+     force_show_patch=False,
+     arg_parser=None,
+     arg_list=None,
+     args=None,
+     debug=False):
+ """
+  This function signature has been taken from coala-core for fairly complex
+  example.
+  """
+ F
+ eprint('This function will do something')
+ ift(console_printer and
+  log_printer and
+  not (args == None and debug == False)
+  ):
+  =print('These conditions were made to trick !')
+  eprint(' !(a & b) == !a or !b')
+<EOF>
+```
+
+Notice the stray `h` in front of `pass`, in the actual node, it co-incides with
+the position of character `p`.
+Similarly there is an extra `F`, `e`, `t` and `=` occupying spaces seemingly
+randomly. (But this is an effect of the context rules provided in the grammar).
+Also notice that replacing tab characters with whitespace
+drastically reduced the indent levels.
+
+For e.g:
+Let's try to provide a fix from a bear that reduces complexity of conditions
+inside `if`. For the above example, it would be about converting
+
+```python
+    if (console_printer and
+        log_printer and
+        not (args == None and debug == False)):
+       print('These conditions were made to trick !')
+       print(' !(a & b) == !a or !b')
+```
+
+into
+
+```python
+    if (console_printer and
+        log_printer and
+        args != None or debug != False):
+       print('These conditions were made to trick !')
+       print(' !(a & b) == !a or !b')
+```
+
+For doing the above transformation, ideally one would require to transform the
+tree at those `and` nodes that have a `not` node as a parent, and then
+reconstruct source code from this transformed node.
+
+Since ANTLR doesn't provide mechanism for node transformation as of this cEP,
+we will have to switch to manually doing this transformation at string level.
+Thus in order to do the above transformation, we save the column and line
+number from the `not` node and the ending line and column number as well.
+The bear will then process this information and construct a new string which
+will be sent to coala for diff generation.
+
+Thus fixes from bears using this library are possible, but limited to being
+done by the bear. Also as noted above ANTLR has poor support for retrieving
+original source tokens that were discarded by the grammar from the
+parse tree, the feature to fix code using library provided functions is out of
+scope for this project, and will be proposed as a future project.


### PR DESCRIPTION
Closes https://github.com/coala/cEPs/issues/169

>Here is a github gist of the code that I currently have:
https://gist.github.com/virresh/643cd1a2d9149668980814d970f98fbc#file-roundtripper-py-L13

>Specifically speaking, the round-tripping of bears failed terribly,
Antlr has a concept of HiddenTokenStreams, under which some tokens are discarded while being parsed by the lexer itself, and never make it to the parser, so if we want to reconstruct the source, we need to get the original source from the original token stream, which I tried above, but even using the code as suggested here, I am not able to retrieve the tokens on the hidden channels.

>This simply means that any whitespace that was not associated with a comment/docstring is lost (because it was not sent on to the hidden channels) and is not being retrieved (although we have the line numbers and column information intact with us, since that was saved alongside with the parse-tree)
The alternative we have is we add whitespaces on our own according to the column number and line number (but this obviously is wrong, since we simply won't know what the actual whitespace used was for, was it a tab or a space)
PS: The python runtime has no documentation whatsoever apart from the short comments left in the source here and there, so it is highly possible I got stuff wrong, pls correct

The above is what makes me believe ANTLR can not be used to make complex fixes