### PR TITLE
Add abhishalya and bkhanale to codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # noqa
-*.md @RJ722 @kriti21 @virresh @yzgyyang @bekicot @nemaniarjun @Vamshi99 @ksdme @palash25 @nvzard @MacBox7 @binore @anctartica @sks444 @RaiVaibhav @sangamcse @li-boxuan @ishanSrt @pareksha
+*.md @RJ722 @kriti21 @virresh @yzgyyang @bekicot @nemaniarjun @Vamshi99 @ksdme @palash25 @nvzard @MacBox7 @binore @anctartica @sks444 @RaiVaibhav @sangamcse @li-boxuan @ishanSrt @pareksha @abhishalya @bkhanale


### PR DESCRIPTION
This adds new codeowners to the repository to be able
merge the new cEPs created as a part of GSoC'21.